### PR TITLE
feat(cli): start from cli using `a11y-viewer <url> [--port number] [--open]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # a11y Viewer
 
-**Emulate visual imparity, color blindness and inability to use a pointer.**
-
+**Simulate vision loss, color blindness or inability to use a pointer.**
 
 ## Demo
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,79 @@
 # a11y Viewer
 
-Simulate blindness, color blindness and disability to use mouse.
+**Emulate visual imparity, color blindness and inability to use a pointer.**
+
 
 ## Demo
 
 Checkout the [live demo!](https://voorhoede.github.io/a11y-viewer/)
 
-## Run it locally
+Note: The online demo is restricted to HTTPS and web pages allowed inside an iframe.
+If you [install the a11y-viewer](#install) locally, you don't have these restrictions.
 
-Install dependencies by running `npm install`
 
-Build: `npm run build`
+## Install
 
-Start server: `npm start`
+The a11y-viewer is written in [Node.js](http://nodejs.org/) and can be installed via [npm](https://npmjs.org/):
 
-Watch for file changes: `npm run watch`
+```bash
+npm install a11y-viewer
+```
+
+## Command Line usage
+
+You can start the a11y-viewer directly from the command line:
+
+```bash
+a11y-viewer [url] [--port number] [--open]
+```
+
+### Options
+
+All options are optional.
+
+#### `url`
+
+If you provide a URL for a specific web page (e.g. `https://www.voorhoede.nl`), the a11y-viewer will start on this page.
+
+#### `--port number`
+
+Port number to start a11y-viewer on (e.g. `--port 3000`). Defaults to `1119` ("a11y" in T9).
+
+#### `--open`
+
+If you pass this option, the a11y-viewer will start and open in your default browser.
+
+
+### Help
+
+You can view all options at any time using `--help`:
+
+```bash
+a11y-viewer --help
+```
+
+### Examples
+
+**Start a11y-viewer** with default index:
+
+```bash
+a11y-viewer
+```
+
+Start a11y-viewer **for specific web page**:
+
+```bash
+a11y-viewer https://www.voorhoede.nl
+```
+
+Start a11y-viewer **on specific port**:
+
+```bash
+a11y-viewer https://www.voorhoede.nl --port 3000
+```
+
+Start a11y-viewer and **open in browser**:
+
+```bash
+a11y-viewer https://www.voorhoede.nl --port 3000 --open
+```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ If you [install the a11y-viewer](#install) locally, you don't have these restric
 The a11y-viewer is written in [Node.js](http://nodejs.org/) and can be installed via [npm](https://npmjs.org/):
 
 ```bash
-npm install a11y-viewer
+npm install -g a11y-viewer
 ```
 
 ## Command Line usage

--- a/bin/a11y-viewer
+++ b/bin/a11y-viewer
@@ -1,0 +1,33 @@
+#!/usr/bin/env node
+
+const commander = require('commander'); // cli argument parser
+const ecstatic = require('ecstatic');   // static file server middleware
+const http = require('http');
+const opener = require("opener");
+const path = require('path');
+
+const pkg = require('../package');
+
+
+const program = commander
+    .version(pkg.version)
+    .description(`${pkg.name} (v${pkg.version}): ${pkg.description}`)
+    .usage('<url> [options]')
+    .option('-o, --open', 'Open in browser')
+    .option('-p, --port [value]', 'Port to start server on', parseInt)
+    .parse(process.argv);
+
+
+const url = program.args[0];
+const port = program.port || 1119; // 1119 is "a11y" in T9
+
+
+http.createServer(ecstatic({
+    root: path.join(__dirname, '/../dist/')
+}))
+.listen(port, function() {
+    console.log('a11y-viewer' + (url ? `for ${url}` : '') + ` available on http://localhost:${port}`);
+    if (program.open) {
+        opener(`http://localhost:${port}/` + (url ? `?url=${url}` : ''));
+    }
+});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "a11y-viewer",
   "version": "0.1.0",
-  "description": "Emulate visual imparity, color blindness and inability to use a pointer.",
+  "description": "Simulate vision loss, color blindness or inability to use a pointer.",
   "bin": {
     "a11y-viewer": "./bin/a11y-viewer"
   },

--- a/package.json
+++ b/package.json
@@ -1,8 +1,10 @@
 {
   "name": "a11y-viewer",
-  "version": "0.0.1",
-  "description": "Emulate several forms of visual imparity for developing better accessible websites",
-  "main": "index.js",
+  "version": "0.1.0",
+  "description": "Emulate visual imparity, color blindness and inability to use a pointer.",
+  "bin": {
+    "a11y-viewer": "./bin/a11y-viewer"
+  },
   "scripts": {
     "prebuild": "rimraf dist/ && mkdirp dist/",
     "build": "npm-run-all --parallel build:css build:html build:js",
@@ -17,7 +19,11 @@
   },
   "keywords": [
     "a11y",
-    "accessibility"
+    "accessibility",
+    "blindness",
+    "emulator",
+    "simulator",
+    "viewer"
   ],
   "repository": {
     "type": "git",
@@ -33,6 +39,11 @@
     "url": "https://github.com/voorhoede/a11y-viewer/issues"
   },
   "homepage": "https://github.com/voorhoede/a11y-viewer#readme",
+  "dependencies": {
+    "commander": "2.9.0",
+    "ecstatic": "2.1.0",
+    "opener": "1.4.1"
+  },
   "devDependencies": {
     "autoprefixer": "6.3.7",
     "chokidar-cli": "1.2.0",

--- a/src/assets/a11y-viewer.css
+++ b/src/assets/a11y-viewer.css
@@ -277,7 +277,7 @@ iframe {
 
 /* filters */
 
-/* moderate visual impairment combinations */
+/* moderate vision loss combinations */
 .moderate {
     filter: blur(var(--moderate-blur));
 }
@@ -306,7 +306,7 @@ iframe {
     filter: url('svg-filters.svg#achromatomaly') blur(var(--moderate-blur));
 }
 
-/* severe visual impairment combinations */
+/* severe vision loss combinations */
 .severe {
    filter: blur(var(--severe-blur));
 }

--- a/src/assets/a11y-viewer.js
+++ b/src/assets/a11y-viewer.js
@@ -79,7 +79,7 @@
         switch (formElement) {
             case visionSelect:
                 value = formElement.value;
-                simulateVisualImpairment(value);
+                simulateVisionLoss(value);
                 break;
             case colorSelect:
                 value = formElement.value;
@@ -99,7 +99,7 @@
         }
     }
 
-    function simulateVisualImpairment(value) {
+    function simulateVisionLoss(value) {
 
         visionSelectOptions.forEach(function (option) {
             main.classList.remove(option.value);

--- a/src/index.html
+++ b/src/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title>A11y Viewer</title>
-    <meta name="description" content="Emulate several forms of visual imparity for developing better accessible websites">
-    <meta name="keywords" content="a11y, emulator, visual imparity, color blindness">
+    <meta name="description" content="Simulate vision loss and color blindness for developing better accessible websites">
+    <meta name="keywords" content="a11y, simulator, visual impairment, vision loss, color blindness">
 
     <style>/* INLINE_CSS_PLACEHOLDER */</style>
 
@@ -54,14 +54,14 @@
     <form>
 
         <label class="module-selector-label" for="vision">
-            <span class="a11y-sr-only">Select level of visual imparity</span>
+            <span class="a11y-sr-only">Select level of vision loss</span>
             <select class="module-selector-select" id="vision" name="vision"
                     tabindex="-1"
                     data-input-vision>
-                <optgroup label="Visual imparity">
+                <optgroup label="Vision loss">
                     <option value="normal">Normal vision</option>
-                    <option value="moderate">Moderate visual impairment</option>
-                    <option value="severe">Severe visual impairment</option>
+                    <option value="moderate">Moderate vision loss</option>
+                    <option value="severe">Severe vision loss</option>
                     <option value="blindness">Blindness</option>
                 </optgroup>
             </select>


### PR DESCRIPTION
- registered as `bin` in `package.json`
- fixed `version` to first minor as release can't start with a patch (bug fix)
- removed local dev instructions, should be moved to CONTRIBUTING.md
- requires support of `?url=...` by viewer to actually work
- could later be extended with support for "imparity", "color blindness", "no pointer" as query params
